### PR TITLE
Use `imports-loader` to provide jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,7 @@ module.exports = {
 };
 ```
 
-Bootstrap javascript components depends on jQuery. The simplest way of adding jQuery to your webpack app is by exposing `$` and `jQuery` to global namespace.
-
-``` javascript
-require('expose?$!expose?jQuery!jquery');
-```
-
-Add it before requiring `bootstrap-webpack`. This uses `expose-loader` of webpack. Install [expose-loader](https://github.com/webpack/expose-loader) by `npm install expose-loader --save-dev`.
+Bootstrap javascript components depends on jQuery. This uses `imports-loader` of webpack. Install [imports-loader](https://github.com/webpack/imports-loader) by `npm install imports-loader --save-dev`.
 
 ### Complete Bootstrap
 

--- a/bootstrap-scripts.loader.js
+++ b/bootstrap-scripts.loader.js
@@ -21,6 +21,6 @@ module.exports.pitch = function (configPath) {
   return scripts.filter(function (script) {
     return config.scripts[script];
   }).map(function (script) {
-    return "require(" + JSON.stringify("bootstrap/js/" + script) + ");";
+    return "require(" + JSON.stringify("imports?jQuery=jquery!bootstrap/js/" + script) + ");";
   }).join("\n");
 }


### PR DESCRIPTION
I am trying to create a bundle.js, and using exports-loader in chunks may lead to jQuery undefined sometimes. By using imports-loader, webpack understand dependencies better and work well.

imports-loader makes webpack understand more about dependencies that just export jQuery into global namespace.

There's something wrong with previous pull request, this is the right one.